### PR TITLE
Add custom image ID support

### DIFF
--- a/vggt/dependency/np_to_pycolmap.py
+++ b/vggt/dependency/np_to_pycolmap.py
@@ -256,6 +256,7 @@ def batch_np_matrix_to_pycolmap_wo_track(
     camera = None
     # frame idx
     for fidx in range(N):
+        image_id = int(image_ids[fidx])
         # set camera
         if camera is None or (not shared_camera):
             pycolmap_intri = _build_pycolmap_intri(fidx, intrinsics, camera_type)


### PR DESCRIPTION
## Summary
- ensure `batch_np_matrix_to_pycolmap` assigns IDs from provided list
- propagate image IDs throughout preprocessing and demo scripts
- update helper to map IDs when renaming COLMAP reconstructions

## Testing
- `python -m py_compile preprocess_colmap.py demo_colmap.py vggt/dependency/np_to_pycolmap.py`
- `python preprocess_colmap.py --help` *(fails: No module named 'trimesh')*

------
https://chatgpt.com/codex/tasks/task_e_684e7ada9248832abe06257736c12ed9